### PR TITLE
Bumping dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 		<artifactId>spring-boot-starter-parent</artifactId>
 
 		<!-- NOTE: when updating Spring Boot, be sure to also update the <spring-boot.version> property below -->
-		<version>3.3.1</version>
+		<version>3.3.2</version>
 	</parent>
 
 
@@ -45,10 +45,10 @@
 		<jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
 		<johnzon.version>2.0.1</johnzon.version>
 		<mapstruct.version>1.5.5.Final</mapstruct.version>
-		<opentelemetry-bom.version>1.39.0</opentelemetry-bom.version>
-		<opentelemetry-instrumentation-bom.version>2.5.0-alpha</opentelemetry-instrumentation-bom.version>
-		<spring-boot.version>3.3.1</spring-boot.version>
-		<springdoc.version>2.5.0</springdoc.version>
+		<opentelemetry-bom.version>1.40.0</opentelemetry-bom.version>
+		<opentelemetry-instrumentation-bom.version>2.6.0</opentelemetry-instrumentation-bom.version>
+		<spring-boot.version>3.3.2</spring-boot.version>
+		<springdoc.version>2.6.0</springdoc.version>
 	</properties>
 
 
@@ -187,7 +187,7 @@
 			</dependency>
 			<dependency>
 				<groupId>io.opentelemetry.instrumentation</groupId>
-				<artifactId>opentelemetry-instrumentation-bom-alpha</artifactId>
+				<artifactId>opentelemetry-instrumentation-bom</artifactId>
 				<version>${opentelemetry-instrumentation-bom.version}</version>
 				<type>pom</type>
 				<scope>import</scope>


### PR DESCRIPTION
## Description
Spring Boot: v3.3.1 → v3.3.2

`opentelemetry-bom`: 1.39.0 → 1.40.0
`opentelemetry-instrumentation-bom`: 2.5.0-alpha → 2.6.0 (see https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.6.0)

`springdoc-openapi-starter-webmvc-ui`: 2.5.0 → 2.6.0

## Screenshots
![image](https://github.com/user-attachments/assets/52b85843-8a1a-403b-8690-2342c471a4f5)
